### PR TITLE
feat: enhance featured decks carousel with interactive overlay

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -33,31 +33,55 @@ const items = decksData.decks
     </div>
 
     <div class="pt-8">
-      <div class="container mx-auto">
-        <h2 class="text-2xl font-bold mb-4">Últimos decks</h2>
+      <div class="container mx-auto px-4">
+        <h2 class="text-2xl font-bold mb-4">Decks em destaque</h2>
+
+        <p>Inspire-se nos decks que melhor performaram em eventos anteriores. Participe e veja seus decks aqui!</p>
       </div>
 
       {items.length > 0 ? (
-        <div class="overflow-hidden pt-2 w-full group">
+        <div class="overflow-hidden pt-2 w-full" data-featured-decks>
           <div class="flex gap-2 animated-carousel">
-            {items.map(({ url, img, commander }) => (
-              <a href={url}>
-                <img
-                  class="h-72 transition-all duration-300 ease-out translate-y-16 hover:-translate-y-2 rounded-lg"
-                  src={img}
-                  alt={`Deck de ${commander}`}
-                />
-              </a>
+            {items.map(({ url, img, commander }, idx) => (
+              <div class="group relative rounded-lg overflow-hidden">
+                <input id={`deck-${idx}`} type="radio" name="featured-decks" class="peer sr-only" />
+
+                <div class="relative rounded-lg overflow-hidden translate-y-16 transition-transform duration-300 ease-out group-hover:translate-y-0 peer-checked:translate-y-0">
+                  <label class="block cursor-pointer" for={`deck-${idx}`} aria-label={`Abrir ações do deck de ${commander}`}>
+                    <img class="h-72 rounded-lg" src={img} alt={`Deck de ${commander}`} />
+                  </label>
+
+                  <div class="absolute inset-x-0 bottom-0 p-3 opacity-0 translate-y-2 transition-all duration-200 ease-out group-hover:opacity-100 group-hover:translate-y-0 peer-checked:opacity-100 peer-checked:translate-y-0 pointer-events-none">
+                    <div class="absolute inset-0 bg-gradient-to-t from-black/90 via-black/90 to-transparent"></div>
+                    <div class="relative pointer-events-auto">
+                      <Button href={url} size="sm" className="w-full">
+                        Ver deck
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </div>
             ))}
 
-            {items.map(({ url, img, commander }) => (
-              <a href={url}>
-                <img
-                  class="h-72 transition-all duration-300 ease-out translate-y-16 hover:-translate-y-2 rounded-lg"
-                  src={img}
-                  alt={`Deck de ${commander}`}
-                />
-              </a>
+            {items.map(({ url, img, commander }, idx) => (
+              <div class="group relative rounded-lg overflow-hidden">
+                <input id={`deck-${idx + items.length}`} type="radio" name="featured-decks" class="peer sr-only" />
+
+                <div class="relative rounded-lg overflow-hidden translate-y-16 transition-transform duration-300 ease-out group-hover:translate-y-0 peer-checked:translate-y-0">
+                  <label class="block cursor-pointer" for={`deck-${idx + items.length}`} aria-label={`Abrir ações do deck de ${commander}`}>
+                    <img class="h-72 rounded-lg" src={img} alt={`Deck de ${commander}`} />
+                  </label>
+
+                  <div class="absolute inset-x-0 bottom-0 p-3 opacity-0 translate-y-2 transition-all duration-200 ease-out group-hover:opacity-100 group-hover:translate-y-0 peer-checked:opacity-100 peer-checked:translate-y-0 pointer-events-none">
+                    <div class="absolute inset-0 bg-gradient-to-t from-black/90 via-black/90 to-transparent"></div>
+                    <div class="relative pointer-events-auto">
+                      <Button href={url} size="sm" className="w-full">
+                        Ver deck
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </div>
             ))}
           </div>
         </div>
@@ -99,6 +123,17 @@ const items = decksData.decks
       </div>
     </div>
   </main>
+
+  <script>
+    document.addEventListener('click', e => {
+      const target = e.target;
+      const clickedInside = target instanceof Element ? target.closest('[data-featured-decks]') : null;
+      if (clickedInside) return;
+
+      const selected = document.querySelector('input[type="radio"][name="featured-decks"]:checked');
+      if (selected instanceof HTMLInputElement) selected.checked = false;
+    });
+  </script>
 
   <Footer />
 </BaseLayout>


### PR DESCRIPTION
* Change section title from "Últimos decks" to "Decks em destaque"
* Add descriptive text encouraging participation in events
* Add horizontal padding to section container
* Replace simple hover effect with interactive radio button system for deck selection
* Add overlay with gradient background and "Ver deck" button on hover/selection
* Improve accessibility with aria-labels for deck actions
* Add click-outside handler to deselect active